### PR TITLE
dnsimple: Add support for pagination and list options

### DIFF
--- a/dnsimple/contacts.go
+++ b/dnsimple/contacts.go
@@ -56,9 +56,14 @@ type ContactsResponse struct {
 // ListContacts list the contacts for an account.
 //
 // See https://developer.dnsimple.com/v2/contacts/#list
-func (s *ContactsService) ListContacts(accountID string) (*ContactsResponse, error) {
+func (s *ContactsService) ListContacts(accountID string, options *ListOptions) (*ContactsResponse, error) {
 	path := versioned(contactPath(accountID, nil))
 	contactsResponse := &ContactsResponse{}
+
+	path, err := addListOptions(path, options)
+	if err != nil {
+		return nil, err
+	}
 
 	resp, err := s.client.get(path, contactsResponse)
 	if err != nil {

--- a/dnsimple/dnsimple.go
+++ b/dnsimple/dnsimple.go
@@ -116,7 +116,7 @@ func addListOptions(path string, options interface{}) (string, error) {
 			continue
 		}
 
-		qso[name] = fmt.Sprintf("%v", sv)
+		qso[name] = fmt.Sprint(sv.Interface())
 	}
 
 	// append the options to the URL

--- a/dnsimple/dnsimple_test.go
+++ b/dnsimple/dnsimple_test.go
@@ -7,6 +7,7 @@ import (
 	"io/ioutil"
 	"net/http"
 	"net/http/httptest"
+	"net/url"
 	"reflect"
 	"strings"
 	"testing"
@@ -32,6 +33,12 @@ func teardownMockServer() {
 
 func testMethod(t *testing.T, r *http.Request, want string) {
 	if got := r.Method; want != got {
+		t.Errorf("Request METHOD expected to be `%v`, got `%v`", want, got)
+	}
+}
+
+func testQuery(t *testing.T, r *http.Request, want url.Values) {
+	if got := r.URL.Query(); !reflect.DeepEqual(want, got) {
 		t.Errorf("Request METHOD expected to be `%v`, got `%v`", want, got)
 	}
 }

--- a/dnsimple/domains.go
+++ b/dnsimple/domains.go
@@ -66,9 +66,14 @@ func domainPath(accountID string, domain interface{}) string {
 // ListDomains lists the domains for an account.
 //
 // See https://developer.dnsimple.com/v2/domains/#list
-func (s *DomainsService) ListDomains(accountID string) (*DomainsResponse, error) {
+func (s *DomainsService) ListDomains(accountID string, options *ListOptions) (*DomainsResponse, error) {
 	path := versioned(domainPath(accountID, nil))
 	domainsResponse := &DomainsResponse{}
+
+	path, err := addListOptions(path, options)
+	if err != nil {
+		return nil, err
+	}
 
 	resp, err := s.client.get(path, domainsResponse)
 	if err != nil {

--- a/dnsimple/domains_email_forwards.go
+++ b/dnsimple/domains_email_forwards.go
@@ -39,9 +39,14 @@ func emailForwardPath(accountID string, domain interface{}, forwardID int) strin
 // ListEmailForwards lists the email forwards for a domain.
 //
 // See https://developer.dnsimple.com/v2/domains/email-forwards/#list
-func (s *DomainsService) ListEmailForwards(accountID string, domain interface{}) (*EmailForwardsResponse, error) {
+func (s *DomainsService) ListEmailForwards(accountID string, domain interface{}, options *ListOptions) (*EmailForwardsResponse, error) {
 	path := versioned(emailForwardPath(accountID, domain, 0))
 	forwardsResponse := &EmailForwardsResponse{}
+
+	path, err := addListOptions(path, options)
+	if err != nil {
+		return nil, err
+	}
 
 	resp, err := s.client.get(path, forwardsResponse)
 	if err != nil {

--- a/dnsimple/live_test.go
+++ b/dnsimple/live_test.go
@@ -59,7 +59,7 @@ func TestLive_Domains(t *testing.T) {
 
 	accountID := whoami.Account.ID
 
-	domainsResponse, err := dnsimpleClient.Domains.ListDomains(fmt.Sprintf("%v", accountID))
+	domainsResponse, err := dnsimpleClient.Domains.ListDomains(fmt.Sprintf("%v", accountID), nil)
 	if err != nil {
 		t.Fatalf("Live Domains.List() returned error: %v", err)
 	}
@@ -107,7 +107,7 @@ func TestLive_Webhooks(t *testing.T) {
 	}
 	accountID := whoami.Account.ID
 
-	webhooksResponse, err = dnsimpleClient.Webhooks.List(fmt.Sprintf("%v", accountID))
+	webhooksResponse, err = dnsimpleClient.Webhooks.List(fmt.Sprintf("%v", accountID), nil)
 	if err != nil {
 		t.Fatalf("Live Webhooks.List() returned error: %v", err)
 	}

--- a/dnsimple/tlds.go
+++ b/dnsimple/tlds.go
@@ -35,9 +35,14 @@ type TldsResponse struct {
 // ListTlds lists the supported TLDs.
 //
 // See https://developer.dnsimple.com/v2/tlds/#list
-func (s *TldsService) ListTlds() (*TldsResponse, error) {
+func (s *TldsService) ListTlds(options *ListOptions) (*TldsResponse, error) {
 	path := versioned("/tlds")
 	tldsResponse := &TldsResponse{}
+
+	path, err := addListOptions(path, options)
+	if err != nil {
+		return nil, err
+	}
 
 	resp, err := s.client.get(path, tldsResponse)
 	if err != nil {

--- a/dnsimple/tlds_test.go
+++ b/dnsimple/tlds_test.go
@@ -3,6 +3,7 @@ package dnsimple
 import (
 	"io"
 	"net/http"
+	"net/url"
 	"testing"
 )
 
@@ -20,7 +21,7 @@ func TestTldsService_ListTlds(t *testing.T) {
 		io.Copy(w, httpResponse.Body)
 	})
 
-	tldsResponse, err := client.Tlds.ListTlds()
+	tldsResponse, err := client.Tlds.ListTlds(nil)
 	if err != nil {
 		t.Fatalf("Tlds.ListTlds() returned error: %v", err)
 	}
@@ -34,6 +35,26 @@ func TestTldsService_ListTlds(t *testing.T) {
 		t.Fatalf("Tlds.ListTlds() returned Tld expected to be `%v`, got `%v`", want, got)
 	}
 }
+
+func TestTldsService_ListTlds_WithOptions(t *testing.T) {
+	setupMockServer()
+	defer teardownMockServer()
+
+	mux.HandleFunc("/v2/tlds", func(w http.ResponseWriter, r *http.Request) {
+		httpResponse := httpResponseFixture(t, "/listTlds/success.http")
+
+		testQuery(t, r, url.Values{"page": []string{"2"}, "per_page": []string{"20"}})
+
+		w.WriteHeader(httpResponse.StatusCode)
+		io.Copy(w, httpResponse.Body)
+	})
+
+	_, err := client.Tlds.ListTlds(&ListOptions{Page: 2, PerPage: 20})
+	if err != nil {
+		t.Fatalf("Tlds.ListTlds() returned error: %v", err)
+	}
+}
+
 func TestTldsService_GetTld(t *testing.T) {
 	setupMockServer()
 	defer teardownMockServer()

--- a/dnsimple/webhooks.go
+++ b/dnsimple/webhooks.go
@@ -42,7 +42,7 @@ func webhookPath(accountID string, webhookID int) (path string) {
 // List the webhooks.
 //
 // See PRIVATE
-func (s *WebhooksService) List(accountID string) (*WebhooksResponse, error) {
+func (s *WebhooksService) List(accountID string, _ *ListOptions) (*WebhooksResponse, error) {
 	path := versioned(webhookPath(accountID, 0))
 	webhooksResponse := &WebhooksResponse{}
 

--- a/dnsimple/webhooks_test.go
+++ b/dnsimple/webhooks_test.go
@@ -31,7 +31,7 @@ func TestWebhooksService_List(t *testing.T) {
 		io.Copy(w, httpResponse.Body)
 	})
 
-	webhooksResponse, err := client.Webhooks.List("1010")
+	webhooksResponse, err := client.Webhooks.List("1010", nil)
 	if err != nil {
 		t.Fatalf("Webhooks.List() returned error: %v", err)
 	}

--- a/dnsimple/zones.go
+++ b/dnsimple/zones.go
@@ -37,9 +37,14 @@ type ZonesResponse struct {
 // ListZones the zones for an account.
 //
 // See https://developer.dnsimple.com/v2/zones/#list
-func (s *ZonesService) ListZones(accountID string) (*ZonesResponse, error) {
+func (s *ZonesService) ListZones(accountID string, options *ListOptions) (*ZonesResponse, error) {
 	path := versioned(fmt.Sprintf("/%v/zones", accountID))
 	zonesResponse := &ZonesResponse{}
+
+	path, err := addListOptions(path, options)
+	if err != nil {
+		return nil, err
+	}
 
 	resp, err := s.client.get(path, zonesResponse)
 	if err != nil {

--- a/dnsimple/zones_records.go
+++ b/dnsimple/zones_records.go
@@ -44,9 +44,14 @@ func zoneRecordPath(accountID string, zoneID string, recordID int) string {
 // ListRecords lists the zone records for a zone.
 //
 // See https://developer.dnsimple.com/v2/zones/#list
-func (s *ZonesService) ListRecords(accountID string, zoneID string) (*ZoneRecordsResponse, error) {
+func (s *ZonesService) ListRecords(accountID string, zoneID string, options *ListOptions) (*ZoneRecordsResponse, error) {
 	path := versioned(zoneRecordPath(accountID, zoneID, 0))
 	recordsResponse := &ZoneRecordsResponse{}
+
+	path, err := addListOptions(path, options)
+	if err != nil {
+		return nil, err
+	}
 
 	resp, err := s.client.get(path, recordsResponse)
 	if err != nil {

--- a/dnsimple/zones_test.go
+++ b/dnsimple/zones_test.go
@@ -3,6 +3,7 @@ package dnsimple
 import (
 	"io"
 	"net/http"
+	"net/url"
 	"reflect"
 	"testing"
 )
@@ -21,9 +22,7 @@ func TestZonesService_ListZones(t *testing.T) {
 		io.Copy(w, httpResponse.Body)
 	})
 
-	accountID := "1010"
-
-	zonesResponse, err := client.Zones.ListZones(accountID)
+	zonesResponse, err := client.Zones.ListZones("1010", nil)
 	if err != nil {
 		t.Fatalf("Zones.ListZones() returned error: %v", err)
 	}
@@ -38,6 +37,25 @@ func TestZonesService_ListZones(t *testing.T) {
 	}
 	if want, got := "example-alpha.com", zones[0].Name; want != got {
 		t.Fatalf("Zones.ListZones() returned Name expected to be `%v`, got `%v`", want, got)
+	}
+}
+
+func TestZonesService_ListZones_WithOptions(t *testing.T) {
+	setupMockServer()
+	defer teardownMockServer()
+
+	mux.HandleFunc("/v2/1010/zones", func(w http.ResponseWriter, r *http.Request) {
+		httpResponse := httpResponseFixture(t, "/listZones/success.http")
+
+		testQuery(t, r, url.Values{"page": []string{"2"}, "per_page": []string{"20"}})
+
+		w.WriteHeader(httpResponse.StatusCode)
+		io.Copy(w, httpResponse.Body)
+	})
+
+	_, err := client.Zones.ListZones("1010", &ListOptions{Page: 2, PerPage: 20})
+	if err != nil {
+		t.Fatalf("Zones.ListZones() returned error: %v", err)
 	}
 }
 


### PR DESCRIPTION
Examples:

```go
client.Domains.ListDomains("1010", nil)
client.Domains.ListDomains("1010", &ListOptions{Page: 2, PerPage: 20})
```

There is a base `ListOptions` struct. In the future, list methods can create custom list options (if we should introduce specific listing parameters on a per-method basis).

For example, filtering records per Name or Type could be achieved by defining

```
type RecordListOptions struct {
        ListOptions

	Type string `url:"type,omitempty"`
	Name string `url:"name,omitempty"`
}
```

---

Closes GH-10 /cc @aeden 