### PR TITLE
Add response_type=code to Oauth.AuthorizeURL output.

### DIFF
--- a/dnsimple/oauth.go
+++ b/dnsimple/oauth.go
@@ -55,6 +55,7 @@ func (s *OauthService) AuthorizeURL(clientID string, options *AuthorizationOptio
 	uri, _ := url.Parse(strings.Replace(s.client.BaseURL, "api.", "", 1))
 	query := uri.Query()
 	query.Add("client_id", clientID)
+	query.Add("response_type", "code")
 	if options != nil {
 		if options.RedirectURI != "" {
 			query.Add("redirect_uri", options.RedirectURI)

--- a/dnsimple/oauth_test.go
+++ b/dnsimple/oauth_test.go
@@ -43,11 +43,11 @@ func TestOauthService_AuthorizeURL(t *testing.T) {
 	clientID := "a1b2c3"
 	client.BaseURL = "https://api.host.test"
 
-	if want, got := "https://host.test?client_id=a1b2c3", client.Oauth.AuthorizeURL(clientID, nil); want != got {
+	if want, got := "https://host.test?client_id=a1b2c3&response_type=code", client.Oauth.AuthorizeURL(clientID, nil); want != got {
 		t.Errorf("AuthorizeURL = %v, want %v", got, want)
 	}
 
-	if want, got := "https://host.test?client_id=a1b2c3&state=randomstate", client.Oauth.AuthorizeURL(clientID, &AuthorizationOptions{State: "randomstate"}); want != got {
+	if want, got := "https://host.test?client_id=a1b2c3&response_type=code&state=randomstate", client.Oauth.AuthorizeURL(clientID, &AuthorizationOptions{State: "randomstate"}); want != got {
 		t.Errorf("AuthorizeURL = %v, want %v", got, want)
 	}
 }


### PR DESCRIPTION
This is currently the only response_type supported by the DNSimple API.

Documented in https://developer.dnsimple.com/v2/oauth/