### PR TITLE
Permit creation of records at apex.

### DIFF
--- a/dnsimple/zones_records.go
+++ b/dnsimple/zones_records.go
@@ -10,7 +10,7 @@ type ZoneRecord struct {
 	ZoneID       string `json:"zone_id,omitempty"`
 	ParentID     int    `json:"parent_id,omitempty"`
 	Type         string `json:"type,omitempty"`
-	Name         string `json:"name,omitempty"`
+	Name         string `json:"name"`
 	Content      string `json:"content,omitempty"`
 	TTL          int    `json:"ttl,omitempty"`
 	Priority     int    `json:"priority,omitempty"`

--- a/dnsimple/zones_records_test.go
+++ b/dnsimple/zones_records_test.go
@@ -133,9 +133,6 @@ func TestZonesService_CreateRecord_BlankName(t *testing.T) {
 	}
 
 	record := recordResponse.Data
-	if want, got := 64784, record.ID; want != got {
-		t.Fatalf("Zones.CreateRecord() returned ID expected to be `%v`, got `%v`", want, got)
-	}
 	if want, got := "", record.Name; want != got {
 		t.Fatalf("Zones.CreateRecord() returned Name expected to be `%v`, got `%v`", want, got)
 	}

--- a/dnsimple/zones_records_test.go
+++ b/dnsimple/zones_records_test.go
@@ -107,6 +107,40 @@ func TestZonesService_CreateRecord(t *testing.T) {
 	}
 }
 
+func TestZonesService_CreateRecord_BlankName(t *testing.T) {
+	setupMockServer()
+	defer teardownMockServer()
+
+	mux.HandleFunc("/v2/1010/zones/example.com/records", func(w http.ResponseWriter, r *http.Request) {
+		httpResponse := httpResponseFixture(t, "/createZoneRecord/created_apex.http")
+
+		testMethod(t, r, "POST")
+		testHeaders(t, r)
+
+		want := map[string]interface{}{"name": "", "content": "192.168.0.10", "type": "A"}
+		testRequestJSON(t, r, want)
+
+		w.WriteHeader(httpResponse.StatusCode)
+		io.Copy(w, httpResponse.Body)
+	})
+
+	accountID := "1010"
+	recordValues := ZoneRecord{Name: "", Content: "192.168.0.10", Type: "A"}
+
+	recordResponse, err := client.Zones.CreateRecord(accountID, "example.com", recordValues)
+	if err != nil {
+		t.Fatalf("Zones.CreateRecord() returned error: %v", err)
+	}
+
+	record := recordResponse.Data
+	if want, got := 64784, record.ID; want != got {
+		t.Fatalf("Zones.CreateRecord() returned ID expected to be `%v`, got `%v`", want, got)
+	}
+	if want, got := "", record.Name; want != got {
+		t.Fatalf("Zones.CreateRecord() returned Name expected to be `%v`, got `%v`", want, got)
+	}
+}
+
 func TestZonesService_GetRecord(t *testing.T) {
 	setupMockServer()
 	defer teardownMockServer()

--- a/fixtures.http/createZoneRecord/created_apex.http
+++ b/fixtures.http/createZoneRecord/created_apex.http
@@ -1,0 +1,18 @@
+HTTP/1.1 201 Created
+Server: nginx
+Date: Thu, 07 Jan 2016 17:45:13 GMT
+Content-Type: application/json; charset=utf-8
+Transfer-Encoding: chunked
+Connection: keep-alive
+Status: 201 Created
+X-RateLimit-Limit: 4000
+X-RateLimit-Remaining: 3990
+X-RateLimit-Reset: 1452188712
+ETag: W/"a7ddff4ee5dc28bbebf3d416e8bd0f04"
+Cache-Control: max-age=0, private, must-revalidate
+X-Request-Id: f96f5034-bf0c-4201-9564-493c162e3cb4
+X-Runtime: 0.099095
+Strict-Transport-Security: max-age=31536000
+
+{"data":{"id":64784,"zone_id":"example.com","parent_id":null,"name":"","content":"127.0.0.1","ttl":600,"priority":null,"type":"A","system_record":false,"created_at":"2016-01-07T17:45:13.653Z","updated_at":"2016-01-07T17:45:13.653Z"}}
+


### PR DESCRIPTION
To support creation of records at the apex, an empty string needs to be sent in the JSON during record creation.