### PR TITLE
Add GrantType constants to facilitate passing the GrantType param

### DIFF
--- a/dnsimple/oauth.go
+++ b/dnsimple/oauth.go
@@ -5,6 +5,16 @@ import (
 	"strings"
 )
 
+// GrantType is a string that identifies a particular grant type in the exchange request.
+type GrantType string
+
+const (
+	// AuthorizationCodeGrant is the type of access token request
+	// for an Authorization Code Grant flow.
+	// https://tools.ietf.org/html/rfc6749#section-4.1
+	AuthorizationCodeGrant = GrantType("authorization_code")
+)
+
 // OauthService handles communication with the authorization related
 // methods of the DNSimple API.
 //
@@ -29,7 +39,7 @@ type ExchangeAuthorizationRequest struct {
 	ClientSecret string `json:"client_secret"`
 	RedirectURI  string `json:"redirect_uri,omitempty"`
 	// Currently the only supported value is "authorization_code"
-	GrantType string `json:"grant_type,omitempty"`
+	GrantType GrantType `json:"grant_type,omitempty"`
 }
 
 // ExchangeAuthorizationForToken exchanges the short-lived authorization code for an access token

--- a/dnsimple/oauth.go
+++ b/dnsimple/oauth.go
@@ -37,12 +37,12 @@ type AccessToken struct {
 // an authorization code for an access token.
 // RedirectURI is optional, all the other fields are mandatory.
 type ExchangeAuthorizationRequest struct {
-	Code         string `json:"code"`
-	ClientID     string `json:"client_id"`
-	ClientSecret string `json:"client_secret"`
-	RedirectURI  string `json:"redirect_uri,omitempty"`
-	State        string `json:"state,omitempty"`
-	GrantType GrantType `json:"grant_type,omitempty"`
+	Code         string    `json:"code"`
+	ClientID     string    `json:"client_id"`
+	ClientSecret string    `json:"client_secret"`
+	RedirectURI  string    `json:"redirect_uri,omitempty"`
+	State        string    `json:"state,omitempty"`
+	GrantType    GrantType `json:"grant_type,omitempty"`
 }
 
 // ExchangeAuthorizationError represents a failed request to exchange

--- a/dnsimple/oauth_test.go
+++ b/dnsimple/oauth_test.go
@@ -14,7 +14,6 @@ func TestOauthService_ExchangeAuthorizationForToken(t *testing.T) {
 	code := "1234567890"
 	clientID := "a1b2c3"
 	clientSecret := "thisisasecret"
-	grantType := "authorization_code"
 
 	mux.HandleFunc("/v2/oauth/access_token", func(w http.ResponseWriter, r *http.Request) {
 		httpResponse := httpResponseFixture(t, "/oauthAccessToken/success.http")
@@ -22,14 +21,14 @@ func TestOauthService_ExchangeAuthorizationForToken(t *testing.T) {
 		testMethod(t, r, "POST")
 		testHeaders(t, r)
 
-		want := map[string]interface{}{"code": code, "client_id": clientID, "client_secret": clientSecret, "grant_type": grantType}
+		want := map[string]interface{}{"code": code, "client_id": clientID, "client_secret": clientSecret, "grant_type": "authorization_code"}
 		testRequestJSON(t, r, want)
 
 		w.WriteHeader(httpResponse.StatusCode)
 		io.Copy(w, httpResponse.Body)
 	})
 
-	token, err := client.Oauth.ExchangeAuthorizationForToken(&ExchangeAuthorizationRequest{Code: code, ClientID: clientID, ClientSecret: clientSecret, GrantType: grantType})
+	token, err := client.Oauth.ExchangeAuthorizationForToken(&ExchangeAuthorizationRequest{Code: code, ClientID: clientID, ClientSecret: clientSecret, GrantType: AuthorizationCodeGrant})
 	if err != nil {
 		t.Fatalf("Oauth.ExchangeAuthorizationForToken() returned error: %v", err)
 	}


### PR DESCRIPTION
I added a constant, as you suggested.

/cc @aeden 