### PR TITLE
The custom user agent is now appended to the default user agent

### DIFF
--- a/dnsimple/dnsimple.go
+++ b/dnsimple/dnsimple.go
@@ -83,7 +83,7 @@ type ListOptions struct {
 
 // NewClient returns a new DNSimple API client using the given credentials.
 func NewClient(credentials Credentials) *Client {
-	c := &Client{Credentials: credentials, HttpClient: &http.Client{}, BaseURL: defaultBaseURL, UserAgent: defaultUserAgent}
+	c := &Client{Credentials: credentials, HttpClient: &http.Client{}, BaseURL: defaultBaseURL}
 	c.Identity = &IdentityService{client: c}
 	c.Contacts = &ContactsService{client: c}
 	c.Domains = &DomainsService{client: c}
@@ -117,12 +117,31 @@ func (c *Client) NewRequest(method, path string, payload interface{}) (*http.Req
 
 	req.Header.Set("Content-Type", "application/json")
 	req.Header.Add("Accept", "application/json")
-	req.Header.Add("User-Agent", c.UserAgent)
+	req.Header.Add("User-Agent", formatUserAgent(c.UserAgent))
 	for key, value := range c.Credentials.Headers() {
 		req.Header.Add(key, value)
 	}
 
 	return req, nil
+}
+
+// formatUserAgent builds the final user agent to use for HTTP requests.
+//
+// If no custom user agent is provided, the default user agent is used.
+//
+//     dnsimple-go/1.0
+//
+// If a custom user agent is provided, the final user agent is the combination of the custom user agent
+// prepended by the default user agent.
+//
+//     dnsimple-go/1.0 customAgentFlag
+//
+func formatUserAgent(customUserAgent string) string {
+	if customUserAgent == "" {
+		return defaultUserAgent;
+	}
+
+	return fmt.Sprintf("%s %s", defaultUserAgent, customUserAgent)
 }
 
 func versioned(path string) string {

--- a/dnsimple/dnsimple_test.go
+++ b/dnsimple/dnsimple_test.go
@@ -11,6 +11,7 @@ import (
 	"reflect"
 	"strings"
 	"testing"
+	"fmt"
 )
 
 var (
@@ -130,8 +131,20 @@ func TestClient_NewRequest(t *testing.T) {
 
 	// test that default user-agent is attached to the request
 	ua := req.Header.Get("User-Agent")
-	if ua != c.UserAgent {
-		t.Errorf("NewRequest() User-Agent = %v, want %v", ua, c.UserAgent)
+	if ua != defaultUserAgent {
+		t.Errorf("NewRequest() User-Agent = %v, want %v", ua, defaultUserAgent)
+	}
+}
+
+func TestClient_NewRequest_CustomUserAgent(t *testing.T) {
+	c := NewClient(NewOauthTokenCredentials("dnsimple-token"))
+	c.UserAgent = "AwesomeClient"
+	req, _ := c.NewRequest("GET", "/", nil)
+
+	// test that default user-agent is attached to the request
+	ua := req.Header.Get("User-Agent")
+	if want := fmt.Sprintf("%s AwesomeClient", defaultUserAgent); ua != want {
+		t.Errorf("NewRequest() User-Agent = %v, want %v", ua, want)
 	}
 }
 


### PR DESCRIPTION
If no custom user agent is provided, the default user agent is used.

    dnsimple-go/1.0

If a custom user agent is provided, the final user agent is the combination of the custom user agent
prepended by the default user agent.

    dnsimple-go/1.0 customAgentFlag

/cc @jacegu @jodosha This is a change I'd like to apply to all the clients. To make sure we can perform analysis and stats about versions and clients, I'd like the custom user agent to not completely override the agent, but instead extend it.

What do you think?
